### PR TITLE
Fix segfault due to unterminated string.

### DIFF
--- a/main.c
+++ b/main.c
@@ -346,7 +346,7 @@ int main(int argc, char * const *argv)
         printf("Large zip format detected containing %d zipfile(s)\n",
                hdr.count);
 
-        if((name = calloc(strlen(opts.dest) + 3, sizeof(char))) == NULL) {
+        if((name = calloc(strlen(opts.dest) + 4, sizeof(char))) == NULL) {
             FAIL(-8)
         };
 


### PR DESCRIPTION
Allocate an additional byte for our filename buffer to accommodate the
terminating null.  This fix remedies a segfault that can happen during
decryption.

Signed-off-by: Cal Peake cp@absolutedigital.net
